### PR TITLE
feat(settings): API Key 眼睛按钮状态重置 (#50)

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -898,6 +898,9 @@ function updateProviderFormFields(type, currentModel) {
 }
 
 providerTypeSelect.addEventListener('change', () => {
+  // Reset API Key to masked on type switch (#50)
+  providerApikeyInput.type = 'password';
+  apikeyVisibilityIcon.textContent = 'visibility_off';
   updateProviderFormFields(providerTypeSelect.value);
   verifyProviderStatus.classList.add('hidden');
 });
@@ -910,9 +913,9 @@ providerBaseurlInput.addEventListener('change', () => {
 
 function openProviderModal() {
   verifyProviderStatus.classList.add('hidden');
-  // Reset API Key visibility state (#49)
+  // Reset API Key visibility state (#49, #50)
   providerApikeyInput.type = 'password';
-  apikeyVisibilityIcon.textContent = 'visibility';
+  apikeyVisibilityIcon.textContent = 'visibility_off';
   providerModal.classList.remove('hidden');
 }
 
@@ -1013,7 +1016,7 @@ providerModal.addEventListener('click', (e) => {
 toggleApikeyVisibilityBtn.addEventListener('click', () => {
   const isHidden = providerApikeyInput.type === 'password';
   providerApikeyInput.type = isHidden ? 'text' : 'password';
-  apikeyVisibilityIcon.textContent = isHidden ? 'visibility_off' : 'visibility';
+  apikeyVisibilityIcon.textContent = isHidden ? 'visibility' : 'visibility_off';
 });
 
 verifyProviderBtn.addEventListener('click', async () => {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -776,6 +776,8 @@ const providerTypeSelect = document.getElementById('provider-type');
 const providerApikeyField = document.getElementById('provider-apikey-field');
 const providerApikeyInput = document.getElementById('provider-apikey');
 const providerApikeyHint = document.getElementById('provider-apikey-hint');
+const toggleApikeyVisibilityBtn = document.getElementById('toggle-apikey-visibility');
+const apikeyVisibilityIcon = document.getElementById('apikey-visibility-icon');
 const providerBaseurlField = document.getElementById('provider-baseurl-field');
 const providerBaseurlInput = document.getElementById('provider-baseurl');
 const providerModelSelect = document.getElementById('provider-model-select');
@@ -908,6 +910,9 @@ providerBaseurlInput.addEventListener('change', () => {
 
 function openProviderModal() {
   verifyProviderStatus.classList.add('hidden');
+  // Reset API Key visibility state (#49)
+  providerApikeyInput.type = 'password';
+  apikeyVisibilityIcon.textContent = 'visibility';
   providerModal.classList.remove('hidden');
 }
 
@@ -1002,6 +1007,13 @@ cancelProviderModalBtn.addEventListener('click', closeProviderModal);
 
 providerModal.addEventListener('click', (e) => {
   if (e.target === providerModal) closeProviderModal();
+});
+
+// #49 — Toggle API Key visibility in the Provider modal
+toggleApikeyVisibilityBtn.addEventListener('click', () => {
+  const isHidden = providerApikeyInput.type === 'password';
+  providerApikeyInput.type = isHidden ? 'text' : 'password';
+  apikeyVisibilityIcon.textContent = isHidden ? 'visibility_off' : 'visibility';
 });
 
 verifyProviderBtn.addEventListener('click', async () => {

--- a/src/settings.html
+++ b/src/settings.html
@@ -437,7 +437,7 @@
           <div class="relative">
             <input class="form-input w-full rounded-lg border border-border-light dark:border-border-dark bg-input-light dark:bg-input-dark focus:border-primary focus:ring-primary/50 text-text-primary-light dark:text-text-primary-dark h-11 px-4 pr-10" id="provider-apikey" placeholder="sk-..." type="password"/>
             <button id="toggle-apikey-visibility" type="button" class="absolute inset-y-0 right-0 flex items-center pr-3 text-text-secondary-light dark:text-text-secondary-dark hover:text-text-primary-light dark:hover:text-text-primary-dark" aria-label="切换 API Key 可见性">
-              <span id="apikey-visibility-icon" class="material-symbols-outlined text-base">visibility</span>
+              <span id="apikey-visibility-icon" class="material-symbols-outlined text-base">visibility_off</span>
             </button>
           </div>
           <p id="provider-apikey-hint" class="text-xs text-text-secondary-light dark:text-text-secondary-dark mt-1 hidden">API Key 可选</p>

--- a/src/settings.html
+++ b/src/settings.html
@@ -434,7 +434,12 @@
         </div>
         <div id="provider-apikey-field">
           <label class="block text-sm font-medium text-text-primary-light dark:text-text-primary-dark pb-2" for="provider-apikey">API Key</label>
-          <input class="form-input w-full rounded-lg border border-border-light dark:border-border-dark bg-input-light dark:bg-input-dark focus:border-primary focus:ring-primary/50 text-text-primary-light dark:text-text-primary-dark h-11 px-4" id="provider-apikey" placeholder="sk-..." type="password"/>
+          <div class="relative">
+            <input class="form-input w-full rounded-lg border border-border-light dark:border-border-dark bg-input-light dark:bg-input-dark focus:border-primary focus:ring-primary/50 text-text-primary-light dark:text-text-primary-dark h-11 px-4 pr-10" id="provider-apikey" placeholder="sk-..." type="password"/>
+            <button id="toggle-apikey-visibility" type="button" class="absolute inset-y-0 right-0 flex items-center pr-3 text-text-secondary-light dark:text-text-secondary-dark hover:text-text-primary-light dark:hover:text-text-primary-dark" aria-label="切换 API Key 可见性">
+              <span id="apikey-visibility-icon" class="material-symbols-outlined text-base">visibility</span>
+            </button>
+          </div>
           <p id="provider-apikey-hint" class="text-xs text-text-secondary-light dark:text-text-secondary-dark mt-1 hidden">API Key 可选</p>
         </div>
         <div id="provider-baseurl-field" class="hidden">

--- a/test/settings-theme.test.js
+++ b/test/settings-theme.test.js
@@ -342,17 +342,17 @@ test('API Key eye button toggles visibility and icon (#49)', async (t) => {
 
   assert.ok(toggleBtn, 'eye toggle button exists');
   assert.equal(apikeyInput.type, 'password', 'initial type is password');
-  assert.equal(toggleIcon.textContent.trim(), 'visibility', 'initial icon is visibility');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility_off', 'initial icon is visibility_off');
 
   // First click: show the key
   toggleBtn.click();
   assert.equal(apikeyInput.type, 'text', 'type switches to text after click');
-  assert.equal(toggleIcon.textContent.trim(), 'visibility_off', 'icon switches to visibility_off');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility', 'icon switches to visibility');
 
   // Second click: hide the key again
   toggleBtn.click();
   assert.equal(apikeyInput.type, 'password', 'type switches back to password');
-  assert.equal(toggleIcon.textContent.trim(), 'visibility', 'icon switches back to visibility');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility_off', 'icon switches back to visibility_off');
 
   // State resets when modal is closed and reopened
   toggleBtn.click(); // make it visible
@@ -360,5 +360,113 @@ test('API Key eye button toggles visibility and icon (#49)', async (t) => {
   page.getElementById('cancel-provider-modal').click();
   page.getElementById('add-provider-btn').click();
   assert.equal(apikeyInput.type, 'password', 'type resets to password on reopen');
-  assert.equal(toggleIcon.textContent.trim(), 'visibility', 'icon resets to visibility on reopen');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility_off', 'icon resets to visibility_off on reopen');
+});
+
+// #50 — API Key visibility state resets to masked on every modal open and
+// on provider type switch. The eye icon must always be visibility_off when
+// the input is password-masked.
+test('API Key eye state resets on modal open and provider type switch (#50)', async (t) => {
+  const settings = fs.readFileSync(settingsPath, 'utf8');
+  const dom = new JSDOM(settings, { url: 'http://localhost/settings.html' });
+  const page = dom.window.document;
+
+  const existingProvider = {
+    id: 'p-existing', name: 'My DeepSeek', type: 'deepseek',
+    apiKey: 'sk-secret', model: 'deepseek-v4-flash',
+  };
+
+  const injectedGlobalKeys = [
+    'window', 'document', 'Event', 'KeyboardEvent', 'Node', 'HTMLElement',
+    'getComputedStyle', 'confirm', 'alert', 'providerModule', 'templateModule', 'shortcutDraftModule',
+  ];
+  const originalGlobals = new Map(
+    injectedGlobalKeys.map(key => [key, Object.getOwnPropertyDescriptor(global, key)]),
+  );
+
+  Object.assign(global, {
+    window: dom.window,
+    document: dom.window.document,
+    Event: dom.window.Event,
+    KeyboardEvent: dom.window.KeyboardEvent,
+    Node: dom.window.Node,
+    HTMLElement: dom.window.HTMLElement,
+    getComputedStyle: dom.window.getComputedStyle,
+    confirm: () => true,
+    alert: () => {},
+    providerModule: require('../src/provider'),
+    templateModule: require('../src/template'),
+    shortcutDraftModule: require('../src/shortcut-draft'),
+  });
+  Object.assign(dom.window, {
+    confirm: global.confirm,
+    alert: global.alert,
+    electronAPI: {
+      getConfig: async () => ({ providers: [existingProvider], shortcuts: [] }),
+      saveProvider: async () => {},
+      deleteProvider: async () => {},
+      validateProvider: async () => ({ success: true }),
+      saveShortcut: async () => ({ success: true }),
+      deleteShortcut: async () => {},
+      checkShortcutAvailability: async () => ({ status: 'available' }),
+      recommendShortcut: async () => null,
+      recheckShortcut: async () => ({ recovered: true }),
+    },
+  });
+
+  const rendererPathLocal = require.resolve('../src/renderer');
+  t.after(() => {
+    delete require.cache[rendererPathLocal];
+    dom.window.close();
+    for (const key of injectedGlobalKeys) {
+      const descriptor = originalGlobals.get(key);
+      if (descriptor) {
+        Object.defineProperty(global, key, descriptor);
+      } else {
+        delete global[key];
+      }
+    }
+  });
+
+  delete require.cache[rendererPathLocal];
+  require(rendererPathLocal);
+  await new Promise(resolve => setImmediate(resolve));
+
+  const apikeyInput = page.getElementById('provider-apikey');
+  const toggleIcon = page.getElementById('apikey-visibility-icon');
+  const toggleBtn = page.getElementById('toggle-apikey-visibility');
+
+  // --- Edit existing provider: must open masked ---
+  page.querySelector('.provider-edit-btn').click();
+  assert.equal(apikeyInput.type, 'password', 'edit modal opens with password type');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility_off', 'edit modal opens with visibility_off icon');
+
+  // Unmask, then close and reopen — must be masked again
+  toggleBtn.click();
+  assert.equal(apikeyInput.type, 'text', 'unmasked for editing');
+  page.getElementById('cancel-provider-modal').click();
+  page.querySelector('.provider-edit-btn').click();
+  assert.equal(apikeyInput.type, 'password', 're-edit resets to password');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility_off', 're-edit resets icon to visibility_off');
+
+  // --- Provider type switch resets to masked ---
+  // Open add modal, unmask, then switch type
+  page.getElementById('cancel-provider-modal').click();
+  page.getElementById('add-provider-btn').click();
+  toggleBtn.click(); // unmask
+  assert.equal(apikeyInput.type, 'text', 'unmasked before type switch');
+
+  const typeSelect = page.getElementById('provider-type');
+  typeSelect.value = 'ollama';
+  typeSelect.dispatchEvent(new dom.window.Event('change'));
+  // After switching type, API Key field should be masked again
+  // (even though the field is hidden for ollama, the state resets)
+  assert.equal(apikeyInput.type, 'password', 'type switch resets to password');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility_off', 'type switch resets icon to visibility_off');
+
+  // Switch back to deepseek — still masked
+  typeSelect.value = 'deepseek';
+  typeSelect.dispatchEvent(new dom.window.Event('change'));
+  assert.equal(apikeyInput.type, 'password', 'switch back keeps password');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility_off', 'switch back keeps visibility_off');
 });

--- a/test/settings-theme.test.js
+++ b/test/settings-theme.test.js
@@ -270,3 +270,95 @@ test('blocking Provider deletion flashes the dependent shortcut rows (#47)', asy
   assert.equal(calls.deletedProviders.length, 0, 'Provider is not deleted while blocked');
   assert.ok(page.querySelector('.provider-delete-btn[data-id="provider-A"]'), 'Provider row remains');
 });
+
+// #49 — API Key visibility toggle (eye icon) in the Provider modal.
+// The button sits inside the input, toggles type between password/text,
+// and the icon swaps between visibility / visibility_off.
+test('API Key eye button toggles visibility and icon (#49)', async (t) => {
+  const settings = fs.readFileSync(settingsPath, 'utf8');
+  const dom = new JSDOM(settings, { url: 'http://localhost/settings.html' });
+  const page = dom.window.document;
+  const injectedGlobalKeys = [
+    'window', 'document', 'Event', 'KeyboardEvent', 'Node', 'HTMLElement',
+    'getComputedStyle', 'confirm', 'alert', 'providerModule', 'templateModule', 'shortcutDraftModule',
+  ];
+  const originalGlobals = new Map(
+    injectedGlobalKeys.map(key => [key, Object.getOwnPropertyDescriptor(global, key)]),
+  );
+
+  Object.assign(global, {
+    window: dom.window,
+    document: dom.window.document,
+    Event: dom.window.Event,
+    KeyboardEvent: dom.window.KeyboardEvent,
+    Node: dom.window.Node,
+    HTMLElement: dom.window.HTMLElement,
+    getComputedStyle: dom.window.getComputedStyle,
+    confirm: () => true,
+    alert: () => {},
+    providerModule: require('../src/provider'),
+    templateModule: require('../src/template'),
+    shortcutDraftModule: require('../src/shortcut-draft'),
+  });
+  Object.assign(dom.window, {
+    confirm: global.confirm,
+    alert: global.alert,
+    electronAPI: {
+      getConfig: async () => ({ providers: [], shortcuts: [] }),
+      saveProvider: async () => {},
+      deleteProvider: async () => {},
+      validateProvider: async () => ({ success: true }),
+      saveShortcut: async () => ({ success: true }),
+      deleteShortcut: async () => {},
+      checkShortcutAvailability: async () => ({ status: 'available' }),
+      recommendShortcut: async () => null,
+      recheckShortcut: async () => ({ recovered: true }),
+    },
+  });
+
+  const rendererPathLocal = require.resolve('../src/renderer');
+  t.after(() => {
+    delete require.cache[rendererPathLocal];
+    dom.window.close();
+    for (const key of injectedGlobalKeys) {
+      const descriptor = originalGlobals.get(key);
+      if (descriptor) {
+        Object.defineProperty(global, key, descriptor);
+      } else {
+        delete global[key];
+      }
+    }
+  });
+
+  delete require.cache[rendererPathLocal];
+  require(rendererPathLocal);
+  await new Promise(resolve => setImmediate(resolve));
+
+  // Open the provider modal
+  page.getElementById('add-provider-btn').click();
+  const apikeyInput = page.getElementById('provider-apikey');
+  const toggleBtn = page.getElementById('toggle-apikey-visibility');
+  const toggleIcon = page.getElementById('apikey-visibility-icon');
+
+  assert.ok(toggleBtn, 'eye toggle button exists');
+  assert.equal(apikeyInput.type, 'password', 'initial type is password');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility', 'initial icon is visibility');
+
+  // First click: show the key
+  toggleBtn.click();
+  assert.equal(apikeyInput.type, 'text', 'type switches to text after click');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility_off', 'icon switches to visibility_off');
+
+  // Second click: hide the key again
+  toggleBtn.click();
+  assert.equal(apikeyInput.type, 'password', 'type switches back to password');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility', 'icon switches back to visibility');
+
+  // State resets when modal is closed and reopened
+  toggleBtn.click(); // make it visible
+  assert.equal(apikeyInput.type, 'text');
+  page.getElementById('cancel-provider-modal').click();
+  page.getElementById('add-provider-btn').click();
+  assert.equal(apikeyInput.type, 'password', 'type resets to password on reopen');
+  assert.equal(toggleIcon.textContent.trim(), 'visibility', 'icon resets to visibility on reopen');
+});

--- a/types/browser-globals.d.ts
+++ b/types/browser-globals.d.ts
@@ -20,6 +20,7 @@ interface HTMLElement {
   disabled: boolean;
   placeholder: string;
   value: any;
+  type: string;
 }
 
 interface Element {


### PR DESCRIPTION
## Summary

Closes #50

确保 API Key 字段在每次打开 Provider 模态框和切换 Provider 类型时重置为遮罩状态（password + visibility_off 图标）。

## Changes

- **settings.html**: 默认眼睛图标从 `visibility` 改为 `visibility_off`
- **renderer.js `openProviderModal()`**: 重置图标为 `visibility_off`（修复 #49 实现中的错误映射）
- **renderer.js provider type change handler**: 新增遮罩状态重置逻辑
- **renderer.js toggle handler**: 修正图标映射语义（明文→`visibility`，遮罩→`visibility_off`）
- **tests**: 更新 #49 测试期望值，新增 #50 专项测试（编辑模态框、重新打开、类型切换场景）

## Verification

- ✅ 393/393 tests pass
- ✅ ESLint 0 warnings
- ✅ TypeScript typecheck clean
- ✅ Code coverage 66.64% lines (above 60% threshold)